### PR TITLE
Freebsd fixes

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -1105,6 +1105,9 @@ fi
 #                                                                            #
 ##############################################################################
 
+# prctl.h is Linux-specific "process control"
+AC_CHECK_HEADERS(sys/prctl.h)
+
 # This section gets inserted in to config.h.in when autoheader is run.
 # Global and common defines should be here rather than duplicated in
 # multiple places. Keep screwball constructs out of this, and it can

--- a/src/configure.in
+++ b/src/configure.in
@@ -1108,6 +1108,9 @@ fi
 # prctl.h is Linux-specific "process control"
 AC_CHECK_HEADERS(sys/prctl.h)
 
+# io.h is Linux-specific, for iopl()
+AC_CHECK_HEADERS(sys/io.h)
+
 # This section gets inserted in to config.h.in when autoheader is run.
 # Global and common defines should be here rather than duplicated in
 # multiple places. Keep screwball constructs out of this, and it can

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -45,7 +45,10 @@
 #include <sys/resource.h>
 #include <sys/mman.h>
 #include <malloc.h>
+
+#ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
+#endif
 
 #include "config.h"
 
@@ -651,11 +654,13 @@ static int harden_rt()
 		  "setrlimit: %s - core dumps may be truncated or non-existant\n",
 		  strerror(errno));
 
+#ifdef HAVE_SYS_PRCTL_H
     // even when setuid root
     if (prctl(PR_SET_DUMPABLE, 1) < 0)
 	rtapi_print_msg(RTAPI_MSG_WARN,
 		  "prctl(PR_SET_DUMPABLE) failed: no core dumps will be created - %d - %s\n",
 		  errno, strerror(errno));
+#endif
 
     configure_memory();
 

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -630,12 +630,14 @@ static int harden_rt()
 
     WITH_ROOT;
 #if defined(__x86_64__) || defined(__i386__)
+#if HAVE_SYS_IO_H
     if (iopl(3) < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                         "cannot gain I/O privileges - "
                         "forgot 'sudo make setuid'?\n");
         return -EPERM;
     }
+#endif
 #endif
 
     struct sigaction sig_act = {};


### PR DESCRIPTION
Hi Trasz, here are a couple of minor compile fixes for uspace rtapi_app on FreeBSD 10.  It still doesn't build, but it's a little closer.
